### PR TITLE
Expand range of deepseq dep.

### DIFF
--- a/data-clist.cabal
+++ b/data-clist.cabal
@@ -22,7 +22,7 @@ source-repository head
 
 Library
     Build-Depends: base >= 4 && < 5,
-                   deepseq == 1.1.*,
+                   deepseq >= 1.1 && < 1.4,
                    QuickCheck >= 2.4 && < 2.5
 
     Exposed-Modules:


### PR DESCRIPTION
Only tested with 1.3, but unchanged from when it worked with 1.1; as they're tied to the
version of containers, and the only difference is where various instances are defined
(which doesn't concern us as we only use the list instance), this should work.

This can be a point release, as the API hasn't changed (0.0.7.1 or something).
