### PR TITLE
Ord

### DIFF
--- a/data-clist.cabal
+++ b/data-clist.cabal
@@ -23,7 +23,7 @@ source-repository head
 Library
     Build-Depends: base >= 4 && < 5,
                    deepseq >= 1.1 && < 1.5,
-                   QuickCheck >= 2.4 && < 2.9
+                   QuickCheck >= 2.4 && < 3.0
 
     Exposed-Modules:
         Data.CircularList


### PR DESCRIPTION
Add an Ord instance for CList, and some functions which calculate ‘allRotations’ allowing only certain multiples of rotations to be used. Useful for when the CList represents something with some symmetries, but not all rotations.