### PR TITLE
Bumped stack resolver and QuickCheck upper bound

### DIFF
--- a/data-clist.cabal
+++ b/data-clist.cabal
@@ -23,7 +23,7 @@ source-repository head
 Library
     Build-Depends: base >= 4 && < 5,
                    deepseq >= 1.1 && < 1.5,
-                   QuickCheck >= 2.4 && < 2.11
+                   QuickCheck >= 2.4 && < 2.12
 
     Exposed-Modules:
         Data.CircularList

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,14 +1,14 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: nightly-2017-01-16
+resolver: nightly-2018-03-20
 
 # Local packages, usually specified by relative directory name
 packages:
 - '.'
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps: [QuickCheck-2.10.0.1]
+extra-deps: []
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
This is needed for inclusion in the stack nightly resolver.