### PR TITLE
Bump up QuickCheck bounds

### DIFF
--- a/data-clist.cabal
+++ b/data-clist.cabal
@@ -23,7 +23,7 @@ source-repository head
 Library
     Build-Depends: base >= 4 && < 5,
                    deepseq >= 1.1 && < 1.5,
-                   QuickCheck >= 2.4 && < 2.12
+                   QuickCheck >= 2.4 && < 2.13
 
     Exposed-Modules:
         Data.CircularList

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: nightly-2018-03-20
+resolver: lts-13.0
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
This helps to build with GHC-8.6.3.

If you don't mind these changes could you please also make a revision at Hackage fixing `cabal` file to what is in this PR, so we could use the library with the correct bounds for `QuickCheck`?

Thanks in advance!