### PR TITLE
Bump up upper bounds for QuickCheck

### DIFF
--- a/data-clist.cabal
+++ b/data-clist.cabal
@@ -23,7 +23,7 @@ source-repository head
 Library
     Build-Depends: base >= 4 && < 5,
                    deepseq >= 1.1 && < 1.5,
-                   QuickCheck >= 2.4 && < 2.13
+                   QuickCheck >= 2.4 && < 2.14
 
     Exposed-Modules:
         Data.CircularList

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-13.0
+resolver: nightly-2019-06-01
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
It builds with nightly now, so it could be added to the newest Stackage snapshot.