### PR TITLE
Require Cabal-Version 1.8

### DIFF
--- a/data-clist.cabal
+++ b/data-clist.cabal
@@ -12,7 +12,7 @@ Author: John Van Enk <vanenkj@gmail.com>
 Maintainer: Jeremy Huffman <jeremy@jeremyhuffman.com>, John Van Enk <vanenkj@gmail.com>
 Stability: experimental
 Category: Data Structures
-Cabal-Version: >= 1.6
+Cabal-Version: >= 1.8
 Build-Type: Simple
 Homepage: https://github.com/sw17ch/data-clist
 


### PR DESCRIPTION
Hopefully this suppresses the following warning:

```
Warning: data-clist.cabal:24:32: version operators used. To use version
operators the package needs to specify at least 'cabal-version: >= 1.8'.
```