### PR TITLE
Make rotN more efficient

### DIFF
--- a/tests/quickcheck.hs
+++ b/tests/quickcheck.hs
@@ -10,10 +10,10 @@ instance Arbitrary a => Arbitrary (CList a) where
                 l <- arbitrary
                 f <- arbitrary
                 r <- arbitrary
-                return $ CList l f r
-    shrink (CList l f r) = Empty : [ CList l' f' r' | l' <- shrink l,
+                return $ CList l f r (length l + 1 + length r)
+    shrink (CList l f r _) = Empty : [ CList l' f' r' (length l' + 1 + length r') | l' <- shrink l,
                                                       f' <- shrink f,
-                                                      r' <- shrink r]
+                                                      r' <- shrink r ]
     shrink Empty = []
 
 -- Make sure empty really is empty.


### PR DESCRIPTION
This PR adds a size parameter to the CList type which allows for rotations to be performed modulo the size. Additionally any call to rotN will result in at most size/2 rotations. 

For example, `rotN 9999999 (fromList [1..1000000]` currently does 9999999 right rotations. With this PR it now does 1 left rotation.

Additionally, `rotN 400 (fromList [1,2,3,4])` now does 0 rotations instead of 400. 

Further this means the size function is now O(1).